### PR TITLE
chore: preconf verification gives better error message

### DIFF
--- a/crates/preconfer/src/error.rs
+++ b/crates/preconfer/src/error.rs
@@ -29,6 +29,8 @@ pub enum RpcError {
     SignerClientError(#[from] SignerClientError),
     #[error("Luban pricer error: {0:?}")]
     PricerError(#[from] PricerError),
+    #[error("Escrow Error: {0:?}")]
+    EscrowError(String),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/preconfer/src/preconf_api/state.rs
+++ b/crates/preconfer/src/preconf_api/state.rs
@@ -234,13 +234,7 @@ where
             .verify_escrow_balance_and_calc_fee(&preconf_request.tip_tx.from, &preconf_request)
             .await
         {
-            Ok(res) => {
-                if !res {
-                    return Err(RpcError::UnknownError(
-                        "preconf request not valid".to_string(),
-                    ));
-                }
-            }
+            Ok(_) => {}
             Err(e) => return Err(RpcError::UnknownError(format!("validate error {e:?}"))),
         }
 


### PR DESCRIPTION
Currently , the error message for preconf verification is too vague. Needs to be more concrete for debugging.