### PR TITLE
Add rustfmt and format codes

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,10 @@
+unstable_features = true
+newline_style = "Unix"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+normalize_comments = true
+normalize_doc_attributes = true
+format_code_in_doc_comments = true
+use_field_init_shorthand = true
+use_small_heuristics = "Max"

--- a/crates/cli/src/commands/luban_escrow_deposit.rs
+++ b/crates/cli/src/commands/luban_escrow_deposit.rs
@@ -49,10 +49,7 @@ impl LubanEscrowDepositCommand {
         let luban_escrow = LubanEscrow::new(contract_address, provider.clone());
 
         // Call deposit function
-        let tx = luban_escrow
-            .deposit()
-            .value(self.amount)
-            .into_transaction_request();
+        let tx = luban_escrow.deposit().value(self.amount).into_transaction_request();
 
         let pending_tx = provider.send_transaction(tx).await?;
 

--- a/crates/cli/src/commands/luban_stake.rs
+++ b/crates/cli/src/commands/luban_stake.rs
@@ -6,7 +6,6 @@ use alloy_signer::k256::ecdsa::SigningKey;
 use alloy_signer_local::{coins_bip39::English, LocalSigner, MnemonicBuilder};
 use alloy_sol_types::sol;
 use bip39::{Mnemonic, Seed};
-
 use clap::Parser;
 use eth2_keystore::keypair_from_secret;
 use eth2_wallet::recover_validator_secret_from_mnemonic;
@@ -103,12 +102,9 @@ impl LubanStakeCommand {
             .expect("recover validator secret failed");
             let keypair = keypair_from_secret(wallet.as_bytes()).expect("keypair not good");
             let bls_pub_key = Bytes::from(keypair.pk.serialize());
-            let tx = luban_proposer_registry
-                .optIn(bls_pub_key)
-                .into_transaction_request();
-            let tx = tx
-                .value(U256::from(32000000000000000000u128))
-                .from(validator_signer.address());
+            let tx = luban_proposer_registry.optIn(bls_pub_key).into_transaction_request();
+            let tx =
+                tx.value(U256::from(32000000000000000000u128)).from(validator_signer.address());
             let res = provider.send_transaction(tx).await?;
             info!(
                 "OptIn Validator BLS public key: {:} with {:?}",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,10 +1,10 @@
 mod commands;
 
 use clap::{Parser, Subcommand};
-
-use commands::luban_escrow_deposit::LubanEscrowDepositCommand;
-use commands::luban_stake::LubanStakeCommand;
-use commands::preconfer::PreconferCommand;
+use commands::{
+    luban_escrow_deposit::LubanEscrowDepositCommand, luban_stake::LubanStakeCommand,
+    preconfer::PreconferCommand,
+};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about = "luban", long_about = None)]

--- a/crates/preconfer/src/constraint_client.rs
+++ b/crates/preconfer/src/constraint_client.rs
@@ -18,10 +18,7 @@ impl ConstraintClient {
 
         let client = reqwest::Client::builder().build()?;
 
-        Ok(Self {
-            url: url.into(),
-            client,
-        })
+        Ok(Self { url: url.into(), client })
     }
 
     pub async fn send_set_constraints(

--- a/crates/preconfer/src/error.rs
+++ b/crates/preconfer/src/error.rs
@@ -43,14 +43,7 @@ impl IntoResponse for RpcError {
     fn into_response(self) -> Response {
         let message = self.to_string();
         let code = StatusCode::BAD_REQUEST;
-        (
-            code,
-            Json(ErrorMessage {
-                code: code.as_u16(),
-                message,
-            }),
-        )
-            .into_response()
+        (code, Json(ErrorMessage { code: code.as_u16(), message })).into_response()
     }
 }
 

--- a/crates/preconfer/src/lookahead_fetcher.rs
+++ b/crates/preconfer/src/lookahead_fetcher.rs
@@ -6,7 +6,6 @@ use alloy_provider::Provider;
 use alloy_rpc_types_beacon::{events::HeadEvent, BlsPublicKey};
 use alloy_sol_types::sol;
 use alloy_transport::Transport;
-
 use beacon_api_client::{mainnet::Client, BlockId};
 use futures::TryStreamExt;
 use luban_primitives::ProposerInfo;
@@ -130,10 +129,7 @@ where
                 "Received event: current: {}, epoch: {}, epoch_transition: {}",
                 current_epoch, epoch, event.epoch_transition
             );
-            assert!(
-                (epoch != current_epoch) == event.epoch_transition,
-                "Invalid epoch"
-            );
+            assert!((epoch != current_epoch) == event.epoch_transition, "Invalid epoch");
             if epoch != current_epoch {
                 info!("Epoch changed from {} to {}", current_epoch, epoch);
                 self.update_proposer_duties(epoch).await?;

--- a/crates/preconfer/src/network_state.rs
+++ b/crates/preconfer/src/network_state.rs
@@ -44,10 +44,6 @@ impl NetworkState {
     }
 
     pub fn propser_duty_for_slot(&self, slot: u64) -> Option<ProposerInfo> {
-        self.proposers
-            .read()
-            .iter()
-            .find(|duty| duty.slot == slot)
-            .cloned()
+        self.proposers.read().iter().find(|duty| duty.slot == slot).cloned()
     }
 }

--- a/crates/preconfer/src/preconf_api/api.rs
+++ b/crates/preconfer/src/preconf_api/api.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use alloy_network::Ethereum;
 use alloy_provider::Provider;
 use alloy_transport::Transport;
@@ -13,10 +15,8 @@ use luban_primitives::{
     PreconfRequest, PreconfResponse, PreconfStatusResponse, PreconfTxRequest,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
-use crate::preconf_api::PreconfState;
-use crate::{error::RpcError, pricer::PreconfPricer};
+use crate::{error::RpcError, preconf_api::PreconfState, pricer::PreconfPricer};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GetPreconfRequestQuery {
@@ -36,22 +36,10 @@ where
     fn extra_routes() -> Option<Router<PbsState<PreconfState<T, P, F>>>> {
         Some(
             Router::new()
-                .route(
-                    "/commitments/v1/preconf_request",
-                    post(handle_preconf_request),
-                )
-                .route(
-                    "/commitments/v1/preconf_request",
-                    delete(delete_preconf_request),
-                )
-                .route(
-                    "/commitments/v1/preconf_request/tx",
-                    post(handle_preconf_request_tx),
-                )
-                .route(
-                    "/commitments/v1/preconf_request/:preconf_hash",
-                    get(get_preconf_request),
-                )
+                .route("/commitments/v1/preconf_request", post(handle_preconf_request))
+                .route("/commitments/v1/preconf_request", delete(delete_preconf_request))
+                .route("/commitments/v1/preconf_request/tx", post(handle_preconf_request_tx))
+                .route("/commitments/v1/preconf_request/:preconf_hash", get(get_preconf_request))
                 .route("/commitments/v1/slots", get(get_slots)),
         )
     }
@@ -66,9 +54,7 @@ where
     P: Provider<T, Ethereum> + Clone + Send + Sync + 'static,
     F: PreconfPricer + Clone + Send + Sync + 'static,
 {
-    Ok(Json(
-        state.data.send_preconf_request(preconf_request).await?,
-    ))
+    Ok(Json(state.data.send_preconf_request(preconf_request).await?))
 }
 pub async fn delete_preconf_request<T, P, F>(
     State(state): State<PbsState<PreconfState<T, P, F>>>,
@@ -79,9 +65,7 @@ where
     P: Provider<T, Ethereum> + Clone + Send + Sync + 'static,
     F: PreconfPricer + Clone + Send + Sync + 'static,
 {
-    Ok(Json(
-        state.data.cancel_preconf_request(cancel_request).await?,
-    ))
+    Ok(Json(state.data.cancel_preconf_request(cancel_request).await?))
 }
 
 pub async fn handle_preconf_request_tx<T, P, F>(
@@ -93,12 +77,7 @@ where
     P: Provider<T, Ethereum> + Clone + Send + Sync + 'static,
     F: PreconfPricer + Clone + Send + Sync + 'static,
 {
-    Ok(Json(
-        state
-            .data
-            .send_preconf_tx_request(request.preconf_hash, request.tx)
-            .await?,
-    ))
+    Ok(Json(state.data.send_preconf_tx_request(request.preconf_hash, request.tx).await?))
 }
 pub async fn get_preconf_request<T, P, F>(
     State(state): State<PbsState<PreconfState<T, P, F>>>,
@@ -109,12 +88,7 @@ where
     P: Provider<T, Ethereum> + Clone + Send + Sync + 'static,
     F: PreconfPricer + Clone + Send + Sync + 'static,
 {
-    Ok(Json(
-        state
-            .data
-            .check_preconf_request_status(params.preconf_hash)
-            .await?,
-    ))
+    Ok(Json(state.data.check_preconf_request_status(params.preconf_hash).await?))
 }
 pub async fn get_slots<T, P, F>(
     State(state): State<PbsState<PreconfState<T, P, F>>>,

--- a/crates/preconfer/src/preconf_api/mod.rs
+++ b/crates/preconfer/src/preconf_api/mod.rs
@@ -54,10 +54,7 @@ pub async fn spawn_service(
         event_publiher: maybe_publiher,
     };
 
-    let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
-        .on_builtin(&rpc_url)
-        .await?;
+    let provider = ProviderBuilder::new().with_recommended_fillers().on_builtin(&rpc_url).await?;
     let chain_id = provider.get_chain_id().await?;
     let provider_cl = provider.clone();
     let network_state = NetworkState::new(0, 0, Vec::new());
@@ -66,25 +63,11 @@ pub async fn spawn_service(
     let mut signer_client = SignerClient::new(signer_mod_url, U256::from(chain_id), signer_mod_jwt);
 
     let constraint_client = ConstraintClient::new(
-        cb_config
-            .relays
-            .first()
-            .cloned()
-            .expect("at least one relay")
-            .entry
-            .url
-            .to_string(),
+        cb_config.relays.first().cloned().expect("at least one relay").entry.url.to_string(),
     )?;
-    let pubkeys = signer_client
-        .get_pubkeys()
-        .await
-        .expect("pubkeys should be received.");
-    let pubkeys_dup: Vec<BlsPublicKey> = pubkeys
-        .consensus
-        .clone()
-        .into_iter()
-        .map(|pk| pk.into())
-        .collect();
+    let pubkeys = signer_client.get_pubkeys().await.expect("pubkeys should be received.");
+    let pubkeys_dup: Vec<BlsPublicKey> =
+        pubkeys.consensus.clone().into_iter().map(|pk| pk.into()).collect();
 
     tokio::spawn(async move {
         if let Err(e) = run_cl_process(
@@ -112,13 +95,9 @@ pub async fn spawn_service(
     if pubkeys.proxy_bls.is_empty() {
         info!("Generating proxy keys for preconfer");
         for pubkey in pubkeys.consensus {
-            let proxy_delegation = signer_client
-                .cb_signer_client()
-                .generate_proxy_key_bls(pubkey)
-                .await?;
-            signer_client
-                .proxy_key_map
-                .insert(*pubkey, proxy_delegation.message.proxy.into());
+            let proxy_delegation =
+                signer_client.cb_signer_client().generate_proxy_key_bls(pubkey).await?;
+            signer_client.proxy_key_map.insert(*pubkey, proxy_delegation.message.proxy.into());
         }
     };
 

--- a/crates/preconfer/src/preconf_pool/mod.rs
+++ b/crates/preconfer/src/preconf_pool/mod.rs
@@ -16,10 +16,7 @@ pub struct PreconfPool {
 
 impl PreconfPool {
     pub fn new() -> Self {
-        Self {
-            orderpool: OrderPool::new(),
-            prioritized_orderpool: PrioritizedOrderPool::default(),
-        }
+        Self { orderpool: OrderPool::new(), prioritized_orderpool: PrioritizedOrderPool::default() }
     }
 
     pub fn slot_updated(&mut self, new_slot: u64) {
@@ -49,10 +46,7 @@ impl PreconfPool {
         }
 
         // Check if we can accomodate the preconf request
-        if self
-            .orderpool
-            .is_full(preconf_request.preconf_conditions.slot)
-        {
+        if self.orderpool.is_full(preconf_request.preconf_conditions.slot) {
             return Err(OrderPoolError::MaxCommitmentsReachedForSlot(
                 preconf_request.preconf_conditions.slot,
                 MAX_COMMITMENTS_PER_SLOT,
@@ -60,9 +54,7 @@ impl PreconfPool {
         }
 
         // Check if pool gas limit is reached
-        if self
-            .orderpool
-            .commited_gas(preconf_request.preconf_conditions.slot)
+        if self.orderpool.commited_gas(preconf_request.preconf_conditions.slot)
             + preconf_request.tip_tx.gas_limit.to::<u64>()
             > MAX_GAS_PER_SLOT
         {
@@ -82,11 +74,12 @@ impl PreconfPool {
 
 #[cfg(test)]
 mod tests {
-    use super::PreconfPool;
     use alloy_node_bindings::Anvil;
     use alloy_primitives::{U256, U64};
     use alloy_rpc_client::ClientBuilder;
     use luban_primitives::{OrderingMetaData, PreconfCondition, PreconfRequest, TipTransaction};
+
+    use super::PreconfPool;
 
     #[tokio::test]
     async fn test_prevalidate_req() {
@@ -120,9 +113,7 @@ mod tests {
         assert!(preconf_pool.prevalidate_req(1, &preconf_request).is_ok());
 
         // Add the same preconf request again
-        preconf_pool
-            .orderpool
-            .insert(preconf_request.hash(U256::from(1)), preconf_request.clone());
+        preconf_pool.orderpool.insert(preconf_request.hash(U256::from(1)), preconf_request.clone());
         assert!(preconf_pool.prevalidate_req(1, &preconf_request).is_err());
 
         // Add a preconf request with slot less than current slot

--- a/crates/preconfer/src/preconf_pool/orderpool.rs
+++ b/crates/preconfer/src/preconf_pool/orderpool.rs
@@ -1,5 +1,6 @@
-use luban_primitives::{PreconfHash, PreconfRequest};
 use std::collections::HashMap;
+
+use luban_primitives::{PreconfHash, PreconfRequest};
 
 use crate::preconf_api::state::MAX_COMMITMENTS_PER_SLOT;
 
@@ -26,10 +27,7 @@ impl Default for OrderPool {
 
 impl OrderPool {
     pub fn new() -> Self {
-        Self {
-            known_orders: HashMap::new(),
-            orders_by_target_slot: HashMap::new(),
-        }
+        Self { known_orders: HashMap::new(), orders_by_target_slot: HashMap::new() }
     }
 
     pub fn get(&self, key: &PreconfHash) -> Option<PreconfRequest> {
@@ -42,10 +40,7 @@ impl OrderPool {
 
     pub fn insert(&mut self, key: PreconfHash, value: PreconfRequest) {
         self.known_orders.insert(key, value.clone());
-        self.orders_by_target_slot
-            .entry(value.preconf_conditions.slot)
-            .or_default()
-            .push(key);
+        self.orders_by_target_slot.entry(value.preconf_conditions.slot).or_default().push(key);
     }
 
     pub fn delete(&mut self, key: &PreconfHash) -> Option<PreconfRequest> {
@@ -53,10 +48,8 @@ impl OrderPool {
     }
 
     pub fn head_updated(&mut self, new_slot: u64) {
-        self.known_orders
-            .retain(|_, order| order.preconf_conditions.slot >= new_slot);
-        self.orders_by_target_slot
-            .retain(|slot, _| *slot >= new_slot);
+        self.known_orders.retain(|_, order| order.preconf_conditions.slot >= new_slot);
+        self.orders_by_target_slot.retain(|slot, _| *slot >= new_slot);
     }
 
     pub fn is_full(&self, target_block: u64) -> bool {
@@ -66,13 +59,11 @@ impl OrderPool {
     }
 
     pub fn commited_gas(&self, target_block: u64) -> u64 {
-        self.orders_by_target_slot
-            .get(&target_block)
-            .map_or(0, |v| {
-                v.iter()
-                    .filter_map(|hash| self.known_orders.get(hash))
-                    .map(|order| order.tip_tx.gas_limit.to::<u64>())
-                    .sum()
-            })
+        self.orders_by_target_slot.get(&target_block).map_or(0, |v| {
+            v.iter()
+                .filter_map(|hash| self.known_orders.get(hash))
+                .map(|order| order.tip_tx.gas_limit.to::<u64>())
+                .sum()
+        })
     }
 }

--- a/crates/preconfer/src/preconfer.rs
+++ b/crates/preconfer/src/preconfer.rs
@@ -3,7 +3,6 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use alloy_sol_types::sol;
 use alloy_transport::Transport;
-
 use luban_primitives::PreconfRequest;
 use LubanCore::LubanCoreInstance;
 use LubanEscrow::LubanEscrowInstance;
@@ -57,11 +56,7 @@ where
     ) -> Self {
         let luban_escrow_contract = LubanEscrow::new(luban_escrow_contract_addr, provider.clone());
         let luban_core_contract = LubanCoreInstance::new(luban_core_contract_addr, provider);
-        Self {
-            luban_escrow_contract,
-            luban_core_contract,
-            pricer,
-        }
+        Self { luban_escrow_contract, luban_core_contract, pricer }
     }
     // TODO: take priority gas fee into account when calculating the cost
     /// validate whether the address have enough balance lockedon the escrow contract
@@ -70,16 +65,8 @@ where
         address: &Address,
         preconf_request: &PreconfRequest,
     ) -> eyre::Result<(), RpcError> {
-        let balance = self
-            .luban_escrow_contract
-            .balanceOf(*address)
-            .call()
-            .await?;
-        let lock_block = self
-            .luban_escrow_contract
-            .lockBlockOf(*address)
-            .call()
-            .await?;
+        let balance = self.luban_escrow_contract.balanceOf(*address).call().await?;
+        let lock_block = self.luban_escrow_contract.lockBlockOf(*address).call().await?;
         if lock_block._0 != U256::MAX {
             return Err(RpcError::EscrowError(
                 "from address haven't deposit in escrow contract".to_string(),

--- a/crates/preconfer/src/pricer.rs
+++ b/crates/preconfer/src/pricer.rs
@@ -1,9 +1,10 @@
+use std::marker::PhantomData;
+
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_network::Ethereum;
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_transport::Transport;
-use std::marker::PhantomData;
 
 use crate::error::PricerError;
 
@@ -47,9 +48,7 @@ impl PreconfPricer for LubanFeePricer {
         let body = response.bytes().await?;
 
         let body_str = String::from_utf8_lossy(&body);
-        let res = body_str
-            .parse::<u128>()
-            .map_err(|e| PricerError::ParseError(e.to_string()))?;
+        let res = body_str.parse::<u128>().map_err(|e| PricerError::ParseError(e.to_string()))?;
         Ok(res)
     }
 }
@@ -70,10 +69,7 @@ where
     P: Provider<T, Ethereum> + Clone,
 {
     pub fn new(provider: P) -> Self {
-        Self {
-            provider,
-            phantom: PhantomData,
-        }
+        Self { provider, phantom: PhantomData }
     }
 }
 
@@ -85,10 +81,7 @@ where
     async fn get_optimal_base_gas_fee(&self) -> eyre::Result<u128, PricerError> {
         let block = self
             .provider
-            .get_block(
-                BlockId::Number(BlockNumberOrTag::Latest),
-                BlockTransactionsKind::Hashes,
-            )
+            .get_block(BlockId::Number(BlockNumberOrTag::Latest), BlockTransactionsKind::Hashes)
             .await?
             .ok_or(PricerError::Custom("block not found".to_string()))?;
         let base_fee = block.header.base_fee_per_gas.expect("base fee not found");

--- a/crates/preconfer/src/rpc_state.rs
+++ b/crates/preconfer/src/rpc_state.rs
@@ -12,9 +12,5 @@ pub async fn get_account_state(rpc: String, address: Address) -> eyre::Result<Ac
     let url = rpc.parse()?;
     let provider = ProviderBuilder::new().on_http(url);
     let account = provider.get_account(address).await?;
-    Ok(AccountState {
-        nonce: account.nonce,
-        balance: account.balance,
-        _code: account.code_hash,
-    })
+    Ok(AccountState { nonce: account.nonce, balance: account.balance, _code: account.code_hash })
 }

--- a/crates/preconfer/src/signer_client.rs
+++ b/crates/preconfer/src/signer_client.rs
@@ -1,12 +1,16 @@
+use std::collections::HashMap;
+
 use alloy_primitives::U256;
 use alloy_rpc_types_beacon::{BlsPublicKey, BlsSignature};
-use cb_common::commit::request::GetPubkeysResponse;
-use cb_common::commit::{
-    client::SignerClient as CBSignerClient, error::SignerClientError, request::SignProxyRequest,
+use cb_common::{
+    commit::{
+        client::SignerClient as CBSignerClient,
+        error::SignerClientError,
+        request::{GetPubkeysResponse, SignProxyRequest},
+    },
+    signer::BlsPublicKey as CBBlsPublicKey,
 };
-use cb_common::signer::BlsPublicKey as CBBlsPublicKey;
 use luban_primitives::PreconfRequest;
-use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct SignerClient {
@@ -43,9 +47,7 @@ impl SignerClient {
         let root = preconf_request.hash(self.chain_id);
         let request: SignProxyRequest<CBBlsPublicKey> =
             SignProxyRequest::new(pubkey.into(), root.into());
-        self.cb_signer_client
-            .request_proxy_signature_bls(request)
-            .await
+        self.cb_signer_client.request_proxy_signature_bls(request).await
     }
 
     pub async fn sign_message(
@@ -55,8 +57,6 @@ impl SignerClient {
     ) -> Result<BlsSignature, SignerClientError> {
         let request: SignProxyRequest<CBBlsPublicKey> =
             SignProxyRequest::new(pubkey.into(), message);
-        self.cb_signer_client
-            .request_proxy_signature_bls(request)
-            .await
+        self.cb_signer_client.request_proxy_signature_bls(request).await
     }
 }

--- a/crates/primitives/src/constraints.rs
+++ b/crates/primitives/src/constraints.rs
@@ -69,24 +69,16 @@ impl TryFrom<Vec<PreconfRequest>> for ConstraintsMessage {
                 if preconf_request.preconf_conditions.slot != slot {
                     Err("Slot mismatch".to_string())
                 } else {
-                    preconf_request
-                        .preconf_tx
-                        .ok_or("No preconf tx".to_string())
-                        .map(|tx| {
-                            let re: &[u8] = tx.as_ref();
-                            vec![Constraint {
-                                tx: re.try_into().expect("tx"),
-                            }]
+                    preconf_request.preconf_tx.ok_or("No preconf tx".to_string()).map(|tx| {
+                        let re: &[u8] = tx.as_ref();
+                        vec![Constraint { tx: re.try_into().expect("tx") }]
                             .try_into()
                             .expect("constraint")
-                        })
+                    })
                 }
             })
             .collect::<Result<Vec<List<Constraint, MAX_TRANSACTIONS_PER_BLOCK>>, String>>()?;
-        Ok(Self {
-            slot,
-            constraints: constraints.try_into().expect("constraints"),
-        })
+        Ok(Self { slot, constraints: constraints.try_into().expect("constraints") })
     }
 }
 

--- a/crates/primitives/src/preconf_hash.rs
+++ b/crates/primitives/src/preconf_hash.rs
@@ -29,9 +29,8 @@ pub fn domain_separator(chain_id: U256) -> B256 {
 mod tests {
     use alloy_primitives::U256;
 
-    use crate::preconf_hash::domain_separator;
-
     use super::eip712_domain_typehash;
+    use crate::preconf_hash::domain_separator;
 
     #[test]
     fn eip712_domain_typehash_test() {

--- a/crates/primitives/src/preconf_request.rs
+++ b/crates/primitives/src/preconf_request.rs
@@ -1,11 +1,12 @@
-use super::preconf_hash::domain_separator;
-use crate::PreconfHash;
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
 use alloy_rpc_types_beacon::BlsSignature;
 use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
+
+use super::preconf_hash::domain_separator;
+use crate::PreconfHash;
 
 type Transaction = Vec<u8>;
 
@@ -68,14 +69,7 @@ impl TipTransaction {
         after_pay: U256,
         nonce: U256,
     ) -> Self {
-        Self {
-            gas_limit,
-            from,
-            to,
-            pre_pay,
-            after_pay,
-            nonce,
-        }
+        Self { gas_limit, from, to, pre_pay, after_pay, nonce }
     }
 
     #[inline]
@@ -118,10 +112,7 @@ pub struct PreconfCondition {
 impl PreconfCondition {
     #[allow(dead_code)]
     pub fn new(ordering_meta_data: OrderingMetaData, slot: u64) -> Self {
-        Self {
-            ordering_meta_data,
-            slot,
-        }
+        Self { ordering_meta_data, slot }
     }
 
     #[inline]
@@ -178,12 +169,7 @@ mod tests {
 
     #[test]
     fn test_preconf_condition_hash() {
-        let condition = PreconfCondition::new(
-            super::OrderingMetaData {
-                index: U256::from(0),
-            },
-            0,
-        );
+        let condition = PreconfCondition::new(super::OrderingMetaData { index: U256::from(0) }, 0);
         let h = condition.preconf_condition_hash(U256::from(1337));
         assert_eq!(
             format!("{:x}", h),

--- a/crates/primitives/src/preconf_response.rs
+++ b/crates/primitives/src/preconf_response.rs
@@ -23,10 +23,7 @@ impl PreconfResponse {
             message:
                 "Your preconf request has been successfully received and is pending processing."
                     .to_string(),
-            data: PreconfResponseData {
-                preconf_hash,
-                preconfer_signature,
-            },
+            data: PreconfResponseData { preconf_hash, preconfer_signature },
         }
     }
 }

--- a/examples/src/submit-preconf-request.rs
+++ b/examples/src/submit-preconf-request.rs
@@ -15,16 +15,10 @@ async fn main() -> eyre::Result<()> {
     let el_url = std::env::var("EL_URL").unwrap_or_else(|_| "http://127.0.0.1:8545".to_string());
     let signer_private = std::env::var("PRIVATE_KEY").expect("Input private key");
     let signer: PrivateKeySigner = signer_private.parse().unwrap();
-    let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
-        .on_builtin(&el_url)
-        .await?;
+    let provider = ProviderBuilder::new().with_recommended_fillers().on_builtin(&el_url).await?;
 
     let client = reqwest::Client::new();
-    let res = client
-        .get(&format!("{}/commitments/v1/slots", taiyi_url))
-        .send()
-        .await?;
+    let res = client.get(&format!("{}/commitments/v1/slots", taiyi_url)).send().await?;
     let res_b = res.bytes().await?;
     println!("res: {:?}", res_b);
     let available_slot = serde_json::from_slice::<AvailableSlotResponse>(&res_b)?;
@@ -40,15 +34,11 @@ async fn main() -> eyre::Result<()> {
 
     let tx: Transaction = Transaction::Eip1559(TxEip1559 {
         chain_id: 7014190335,
-        nonce: nonce,
+        nonce,
         max_priority_fee_per_gas: estimate.max_priority_fee_per_gas,
         max_fee_per_gas: estimate.max_fee_per_gas,
         gas_limit: 220000,
-        to: TransactionKind::Call(
-            "0xc998d0300e83d2Bf0eD9abB2A62D25A368adb8ED"
-                .parse()
-                .unwrap(),
-        ),
+        to: TransactionKind::Call("0xc998d0300e83d2Bf0eD9abB2A62D25A368adb8ED".parse().unwrap()),
         value: U256::from(10),
         input: Default::default(),
         access_list: Default::default(),
@@ -68,9 +58,7 @@ async fn main() -> eyre::Result<()> {
     let preconf_request = PreconfRequest {
         preconf_tx: Some(tx_b),
         preconf_conditions: PreconfCondition::new(
-            OrderingMetaData {
-                index: U256::from(3),
-            },
+            OrderingMetaData { index: U256::from(3) },
             target_slot,
         ),
         tip_tx: TipTransaction::new(


### PR DESCRIPTION
It's better that we have a rustfmt config file to format our code.
Now we can format the workspace by `make format`