### PR TITLE
Accelerate CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,13 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy,rustfmt
-          submodules: true
-      - name: Install cargo tools
-        run: |
-          curl -L https://github.com/DevinR528/cargo-sort/releases/download/v1.0.9/cargo-sort-x86_64-unknown-linux-gnu.tar.gz | tar -zxvf - -C ~/.cargo/bin/
-          curl -L https://github.com/est31/cargo-udeps/releases/download/v0.1.47/cargo-udeps-v0.1.47-x86_64-unknown-linux-gnu.tar.gz | tar -xzvf - -C /tmp/
-          mv /tmp/cargo-udeps-v0.1.47-x86_64-unknown-linux-gnu/cargo-udeps ~/.cargo/bin/
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort,cargo-machete
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Format check
-        run: |
-          cargo +nightly fmt --all -- --check
       - name: Lint check
         run: |
           make lint

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ lint:
 	cargo +nightly fmt --all -- --check
 	cargo clippy --all -- -D warnings -A clippy::derive_partial_eq_without_eq -D clippy::unwrap_used -D clippy::uninlined_format_args
 	cargo sort --check --workspace --grouped
-	cargo +nightly udeps --workspace
+	cargo machete


### PR DESCRIPTION
* `cargo machete` is much faster than `cargo udeps`
* remove duplicated tasks.
* refine binaries downloading.