### PR TITLE
use preconf tx alloy types

### DIFF
--- a/contracts/src/libs/PreconfRequestLib.sol
+++ b/contracts/src/libs/PreconfRequestLib.sol
@@ -75,16 +75,13 @@ library PreconfRequestLib {
         );
     }
 
-    function getPreconfTxHash(PreconfTx calldata preconfTx) public pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                preconfTx.from,
-                preconfTx.to,
-                preconfTx.value,
-                preconfTx.callData,
-                preconfTx.callGasLimit,
-                preconfTx.nonce
-            )
+    function encodePreconfTx(PreconfTx calldata preconfTx) public pure returns (bytes memory) {
+        return abi.encode(
+            preconfTx.from, preconfTx.to, preconfTx.value, preconfTx.callData, preconfTx.callGasLimit, preconfTx.nonce
         );
+    }
+
+    function getPreconfTxHash(PreconfTx calldata preconfTx) public pure returns (bytes32) {
+        return keccak256(encodePreconfTx(preconfTx));
     }
 }

--- a/contracts/test/Types.t.sol
+++ b/contracts/test/Types.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import "../src/LubanProposerRegistry.sol";
+import "../src/interfaces/Types.sol";
+import "../src/libs/PreconfRequestLib.sol";
+
+contract PreconTxTest is Test {
+    using PreconfRequestLib for PreconfTx;
+    using PreconfRequestLib for TipTx;
+
+    function setUp() public { }
+
+    function testPreconTxHash() public pure {
+        PreconfTx memory preconfTx = PreconfTx({
+            from: 0xa83114A443dA1CecEFC50368531cACE9F37fCCcb,
+            to: 0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766,
+            value: 1000,
+            callData: hex"11",
+            callGasLimit: 21_000,
+            nonce: 1,
+            signature: ""
+        });
+
+        bytes32 hash = preconfTx.getPreconfTxHash();
+
+        bytes memory encoded = preconfTx.encodePreconfTx();
+        assertEq(
+            encoded,
+            hex"000000000000000000000000a83114a443da1cecefc50368531cace9f37fcccb0000000000000000000000006d2e03b7effeae98bd302a9f836d0d6ab000276600000000000000000000000000000000000000000000000000000000000003e800000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000005208000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000011100000000000000000000000000000000000000000000000000000000000000"
+        );
+        assertEq(hash, bytes32(0x7b61576a8d5323483fd3f578d0adbb469bb77d6674278aeb8550231c0a6e8ff9));
+    }
+
+    function testPreconTxEmptyCalldataHash() public pure {
+        PreconfTx memory preconfTx = PreconfTx({
+            from: 0xa83114A443dA1CecEFC50368531cACE9F37fCCcb,
+            to: 0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766,
+            value: 1000,
+            callData: "",
+            callGasLimit: 21_000,
+            nonce: 1,
+            signature: ""
+        });
+
+        bytes32 hash = preconfTx.getPreconfTxHash();
+
+        assertEq(hash, bytes32(0x5db8eee818de95bee126e27f278d765b7ef486865e46395e991b8527be726c7d));
+    }
+
+    function testTipTxHash() public {
+        TipTx memory tipTx = TipTx({
+            gasLimit: 100_000,
+            from: 0xa83114A443dA1CecEFC50368531cACE9F37fCCcb,
+            to: 0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766,
+            prePay: 1000,
+            afterPay: 2000,
+            nonce: 1,
+            target_slot: 1
+        });
+        vm.chainId(1337);
+        bytes32 hash = tipTx.getTipTxHash();
+        console.logBytes32(PreconfRequestLib.TIP_TX_TYPEHASH);
+
+        assertEq(hash, bytes32(0x200c2a794d5aaf7a95ac301b273412f3e65dca45e052cb513202adcd9a6da79b));
+    }
+}

--- a/crates/preconfer/Cargo.toml
+++ b/crates/preconfer/Cargo.toml
@@ -4,13 +4,11 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-alloy-consensus = { workspace = true }
 alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-network = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
-alloy-rlp = { workspace = true }
 alloy-rpc-client = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-beacon = { workspace = true }

--- a/crates/preconfer/src/contract.rs
+++ b/crates/preconfer/src/contract.rs
@@ -1,0 +1,107 @@
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
+use alloy_primitives::{Address, Bytes};
+use alloy_provider::Provider;
+use alloy_transport::Transport;
+use ethereum_consensus::ssz::prelude::{ByteList, List};
+use taiyi_primitives::{
+    Constraint, ConstraintsMessage, PreconfRequest, MAX_TRANSACTIONS_PER_BLOCK,
+};
+mod core {
+    use alloy_sol_types::sol;
+
+    sol! {
+            struct TipTx {
+                uint256 gasLimit;
+                address from;
+                address to;
+                uint256 prePay;
+                uint256 afterPay;
+                uint256 nonce;
+                uint256 target_slot;
+            }
+
+            struct PreconfTx {
+                address from;
+                address to;
+                uint256 value;
+                bytes callData;
+                uint256 callGasLimit;
+                uint256 nonce;
+                bytes signature;
+            }
+
+            struct PreconfRequest {
+                TipTx tipTx;
+                PreconfTx preconfTx;
+                bytes tipTxSignature;
+                bytes preconferSignature;
+                bytes preconfReqSignature;
+            }
+
+            #[sol(rpc)]
+            contract LubanCore{
+                function batchSettleRequests(PreconfRequest[] calldata preconfReqs) external payable;
+            }
+    }
+}
+
+impl From<PreconfRequest> for core::PreconfRequest {
+    fn from(req: PreconfRequest) -> Self {
+        let preconf_tx = req.preconf_tx.expect("preconf_tx is none");
+        core::PreconfRequest {
+            tipTx: core::TipTx {
+                gasLimit: req.tip_tx.gas_limit,
+                from: req.tip_tx.from,
+                to: req.tip_tx.to,
+                prePay: req.tip_tx.pre_pay,
+                afterPay: req.tip_tx.after_pay,
+                nonce: req.tip_tx.nonce,
+                target_slot: req.tip_tx.target_slot,
+            },
+            preconfTx: core::PreconfTx {
+                from: preconf_tx.from,
+                to: preconf_tx.to,
+                value: preconf_tx.value,
+                callData: preconf_tx.call_data,
+                callGasLimit: preconf_tx.call_gas_limit,
+                nonce: preconf_tx.nonce,
+                signature: preconf_tx.signature,
+            },
+            tipTxSignature: Bytes::from(req.tip_tx_signature.as_bytes()),
+            preconferSignature: Bytes::from(
+                req.preconfer_signature.expect("preconfer_signature is none").as_bytes(),
+            ),
+            preconfReqSignature: Bytes::from(
+                req.preconf_req_signature.expect("preconf_req_signature is none").as_bytes(),
+            ),
+        }
+    }
+}
+
+pub async fn preconf_reqs_to_constraints<T, P>(
+    preconf_reqs: Vec<PreconfRequest>,
+    luban_core_address: Address,
+    provider: P,
+    wallet: EthereumWallet,
+    slot: u64,
+) -> ConstraintsMessage
+where
+    T: Transport + Clone,
+    P: Provider<T, Ethereum> + Clone,
+{
+    let contract = core::LubanCore::LubanCoreInstance::new(luban_core_address, provider);
+    let preconf_reqs: Vec<core::PreconfRequest> =
+        preconf_reqs.into_iter().map(|req| req.into()).collect();
+    let tx = contract.batchSettleRequests(preconf_reqs).into_transaction_request();
+
+    let tx_envelope: Vec<u8> = tx.build(&wallet).await.expect("build tx").encoded_2718();
+    let tx_envelope_ref: &[u8] = tx_envelope.as_ref();
+    let constraint: List<Constraint, MAX_TRANSACTIONS_PER_BLOCK> = vec![Constraint {
+        tx: ByteList::<1_073_741_824usize>::try_from(tx_envelope_ref).expect("tx too big"),
+    }]
+    .try_into()
+    .expect("constraint");
+    let constraints = vec![constraint].try_into().expect("constraints");
+    ConstraintsMessage { slot, constraints }
+}

--- a/crates/preconfer/src/error.rs
+++ b/crates/preconfer/src/error.rs
@@ -56,9 +56,10 @@ pub enum ValidationError {
     /// The gas limit is too high.
     #[error("Gas limit too high")]
     GasLimitTooHigh,
+    /// TODO: Re-enable chainId check https://github.com/lu-bann/taiyi/issues/111s
     /// The transaction chain ID does not match the expected chain ID.
-    #[error("Chain ID mismatch")]
-    ChainIdMismatch,
+    // #[error("Chain ID mismatch")]
+    // ChainIdMismatch,
     /// NOTE: this should not be exposed to the user.
     #[error("Internal error: {0}")]
     Internal(String),

--- a/crates/preconfer/src/lib.rs
+++ b/crates/preconfer/src/lib.rs
@@ -1,4 +1,5 @@
 mod constraint_client;
+mod contract;
 mod error;
 mod lookahead_fetcher;
 mod network_state;

--- a/crates/preconfer/src/preconf_api/mod.rs
+++ b/crates/preconfer/src/preconf_api/mod.rs
@@ -73,7 +73,7 @@ pub async fn spawn_service(
         Some(url) => {
             let base_fee_fetcher = TaiyiFeePricer::new(url.to_string());
             let validator = Preconfer::new(
-                provider,
+                provider.clone(),
                 taiyi_escrow_contract_addr,
                 taiyi_core_contract_addr,
                 base_fee_fetcher,
@@ -86,6 +86,7 @@ pub async fn spawn_service(
                 context,
                 bls_private_key,
                 ecdsa_signer,
+                provider.clone(),
             )
             .await;
 
@@ -106,7 +107,7 @@ pub async fn spawn_service(
         None => {
             let base_fee_fetcher = ExecutionClientFeePricer::new(provider.clone());
             let validator = Preconfer::new(
-                provider,
+                provider.clone(),
                 taiyi_escrow_contract_addr,
                 taiyi_core_contract_addr,
                 base_fee_fetcher,
@@ -119,6 +120,7 @@ pub async fn spawn_service(
                 context,
                 bls_private_key,
                 ecdsa_signer,
+                provider.clone(),
             )
             .await;
 

--- a/crates/preconfer/src/preconf_pool/mod.rs
+++ b/crates/preconfer/src/preconf_pool/mod.rs
@@ -111,6 +111,7 @@ mod tests {
             tip_tx_signature,
             preconfer_signature: None,
             preconf_tx: None,
+            preconf_req_signature: None,
         };
         assert!(preconf_pool.prevalidate_req(1, &preconf_request).is_ok());
 

--- a/crates/preconfer/src/preconfer.rs
+++ b/crates/preconfer/src/preconfer.rs
@@ -90,4 +90,8 @@ where
         }
         Ok(())
     }
+
+    pub fn taiyi_core_contract_addr(&self) -> Address {
+        *self.taiyi_core_contract.address()
+    }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -4,7 +4,6 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types-beacon = { workspace = true }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -5,16 +5,20 @@ mod constraints;
 mod preconf_hash;
 mod preconf_request;
 mod preconf_response;
+mod preconf_tx;
 mod preconf_tx_request;
 mod proposer_info;
 
 pub use available_slot::AvailableSlotResponse;
 pub use cancel_preconf::{CancelPreconfRequest, CancelPreconfResponse};
 pub use check_preconf_response::{PreconfStatus, PreconfStatusResponse};
-pub use constraints::{Constraint, ConstraintsMessage, SignedConstraintsMessage};
+pub use constraints::{
+    Constraint, ConstraintsMessage, SignedConstraintsMessage, MAX_TRANSACTIONS_PER_BLOCK,
+};
 pub use preconf_hash::PreconfHash;
 #[allow(unused_imports)]
 pub use preconf_request::{PreconfRequest, TipTransaction};
 pub use preconf_response::PreconfResponse;
+pub use preconf_tx::PreconfTx;
 pub use preconf_tx_request::PreconfTxRequest;
 pub use proposer_info::ProposerInfo;

--- a/crates/primitives/src/preconf_hash.rs
+++ b/crates/primitives/src/preconf_hash.rs
@@ -15,14 +15,9 @@ pub fn eip712_domain_typehash() -> B256 {
 #[allow(dead_code)]
 pub fn domain_separator(chain_id: U256) -> B256 {
     let typehash = eip712_domain_typehash();
-    let contract_name = keccak256("TaiyiCore".as_bytes());
+    let contract_name = keccak256("LubanCore".as_bytes());
     let version = keccak256("1.0".as_bytes());
-    let mut data = Vec::new();
-    data.extend_from_slice(typehash.tokenize().as_ref());
-    data.extend_from_slice(contract_name.tokenize().as_ref());
-    data.extend_from_slice(version.tokenize().as_ref());
-    data.extend_from_slice(chain_id.tokenize().as_ref());
-    keccak256(data)
+    keccak256((typehash, contract_name, version, chain_id).abi_encode_sequence())
 }
 
 #[cfg(test)]
@@ -46,7 +41,7 @@ mod tests {
         let res = domain_separator(U256::from(1337));
         assert_eq!(
             format!("{res:x}"),
-            "c5e54e20a9ad29abf87784cb9fe36a45b5ca20222503dd672c344fabc500a581"
+            "da358caadda82b600096a11150b79559d2f07fdaac4ddf2425e295c3e432700d"
         );
     }
 }

--- a/crates/primitives/src/preconf_tx.rs
+++ b/crates/primitives/src/preconf_tx.rs
@@ -1,0 +1,89 @@
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_sol_types::SolValue;
+use serde::{Deserialize, Serialize};
+
+// Define the PreconfTx struct in Rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PreconfTx {
+    pub from: Address,        // Ethereum address
+    pub to: Address,          // Ethereum address
+    pub value: U256,          // Transaction value
+    pub call_data: Bytes,     // Transaction calldata bytes
+    pub call_gas_limit: U256, // Gas limit for the call
+    pub nonce: U256,          // Transaction nonce which depends on the contract
+    pub signature: Bytes,     // Transaction ECDSA signature bytes
+}
+
+impl PreconfTx {
+    // Constructor for PreconfTx
+    pub fn new(
+        from: Address,
+        to: Address,
+        value: U256,
+        call_data: Bytes,
+        call_gas_limit: U256,
+        nonce: U256,
+        signature: Bytes,
+    ) -> Self {
+        PreconfTx { from, to, value, call_data, call_gas_limit, nonce, signature }
+    }
+
+    pub fn abi_encode(&self) -> Bytes {
+        (self.from, self.to, self.value, self.call_data.clone(), self.call_gas_limit, self.nonce)
+            .abi_encode_sequence()
+            .into()
+    }
+
+    pub fn hash(&self) -> B256 {
+        keccak256(self.abi_encode())
+    }
+
+    pub fn gas_limit(&self) -> U256 {
+        self.call_gas_limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use alloy_primitives::hex::FromHex;
+
+    use super::*;
+    #[test]
+    fn preconf_tx_hash() {
+        let preconf_tx = PreconfTx::new(
+            "0xa83114A443dA1CecEFC50368531cACE9F37fCCcb".parse().unwrap(),
+            "0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766".parse().unwrap(),
+            U256::from(1000),
+            Bytes::from_hex("0x11").unwrap(),
+            U256::from(21000),
+            U256::from(1),
+            Bytes::default(),
+        );
+
+        let hash = preconf_tx.hash();
+        assert_eq!(
+            format!("{hash:x}"),
+            "7b61576a8d5323483fd3f578d0adbb469bb77d6674278aeb8550231c0a6e8ff9"
+        );
+    }
+
+    #[test]
+    fn preconf_tx_empty_calldata_hash() {
+        let preconf_tx = PreconfTx::new(
+            "0xa83114A443dA1CecEFC50368531cACE9F37fCCcb".parse().unwrap(),
+            "0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766".parse().unwrap(),
+            U256::from(1000),
+            Bytes::default(),
+            U256::from(21000),
+            U256::from(1),
+            Bytes::default(),
+        );
+
+        let hash = preconf_tx.hash();
+        assert_eq!(
+            format!("{hash:x}"),
+            "5db8eee818de95bee126e27f278d765b7ef486865e46395e991b8527be726c7d"
+        );
+    }
+}

--- a/crates/primitives/src/preconf_tx_request.rs
+++ b/crates/primitives/src/preconf_tx_request.rs
@@ -1,10 +1,9 @@
-use alloy_consensus::TxEnvelope;
 use serde::{Deserialize, Serialize};
 
-use crate::PreconfHash;
+use crate::{PreconfHash, PreconfTx};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PreconfTxRequest {
     pub preconf_hash: PreconfHash,
-    pub tx: TxEnvelope,
+    pub tx: PreconfTx,
 }

--- a/examples/src/submit-preconf-request.rs
+++ b/examples/src/submit-preconf-request.rs
@@ -7,7 +7,7 @@ use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer::{Signature, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use reth_primitives::{Transaction, TransactionSigned, TransactionSignedEcRecovered};
-use taiyi_primitives::{AvailableSlotResponse, PreconfRequest, TipTransaction};
+use taiyi_primitives::{AvailableSlotResponse, PreconfRequest, PreconfTx, TipTransaction};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -30,27 +30,27 @@ async fn main() -> eyre::Result<()> {
     let target_slot = available_slot.available_slots.last().expect("last").slot;
     println!("target_slot: {:?}", available_slot);
 
-    let estimate = provider.estimate_eip1559_fees(None).await?;
+    // FIXME: get nonce from contract
     let nonce = provider.get_transaction_count(signer.address()).await?;
 
-    let tx: Transaction = Transaction::Eip1559(TxEip1559 {
-        chain_id: 7014190335,
-        nonce,
-        max_priority_fee_per_gas: estimate.max_priority_fee_per_gas,
-        max_fee_per_gas: estimate.max_fee_per_gas,
-        gas_limit: 220000,
-        to: TxKind::Call("0xc998d0300e83d2Bf0eD9abB2A62D25A368adb8ED".parse().unwrap()),
-        value: U256::from(10),
-        input: Default::default(),
-        access_list: Default::default(),
-    });
-    let sig = signer.sign_hash_sync(&tx.signature_hash())?;
-    let tx = TransactionSignedEcRecovered::from_signed_transaction(
-        TransactionSigned::from_transaction_and_signature(tx, sig),
-        signer.address(),
-    );
+    // let tx: Transaction = Transaction::Eip1559(TxEip1559 {
+    //     chain_id: 7014190335,
+    //     nonce,
+    //     max_priority_fee_per_gas: estimate.max_priority_fee_per_gas,
+    //     max_fee_per_gas: estimate.max_fee_per_gas,
+    //     gas_limit: 220000,
+    //     to: TxKind::Call("0xc998d0300e83d2Bf0eD9abB2A62D25A368adb8ED".parse().unwrap()),
+    //     value: U256::from(10),
+    //     input: Default::default(),
+    //     access_list: Default::default(),
+    // });
+    // let sig = signer.sign_hash_sync(&tx.signature_hash())?;
+    // let tx = TransactionSignedEcRecovered::from_signed_transaction(
+    //     TransactionSigned::from_transaction_and_signature(tx, sig),
+    //     signer.address(),
+    // );
 
-    let tx_b = serde_json::to_vec(&tx.into_signed()).unwrap();
+    // let tx_b = serde_json::to_vec(&tx.into_signed()).unwrap();
     // let preconf_request = PreconfRequest {
     //     preconf_tx: Some(tx_b),
     //     tip_tx: TipTransaction::new(


### PR DESCRIPTION
https://github.com/lu-bann/taiyi/issues/110
https://github.com/lu-bann/taiyi/issues/96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `PreconfTx` struct for handling pre-configuration transactions.
	- Added `batchSettleRequests` function in `LubanCore` contract for batch processing of requests.
	- New `taiyi_core_contract_addr` method in `Preconfer` struct for easy access to contract address.

- **Improvements**
	- Enhanced modularity by separating encoding and hashing logic in the `PreconfRequestLib`.
	- Updated `PreconfRequest` structure to include additional signature fields.
	- Streamlined transaction handling within the `PrioritizedOrderPool`.
	- Refactored transaction handling logic in example usage.

- **Bug Fixes**
	- Improved error handling in service spawning logic for better clarity.

- **Documentation**
	- Updated test cases to reflect changes in transaction handling and expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->