### PR TITLE
fix: fix elect preconfer url path

### DIFF
--- a/bin/taiyi-boost/src/types.rs
+++ b/bin/taiyi-boost/src/types.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_beacon::{BlsPublicKey, BlsSignature};
 use serde::{Deserialize, Serialize};
 use tree_hash_derive::TreeHash;
 
-pub const ELECT_PRECONFER_PATH: &str = "/eth/v1/builder/elect_preconfer";
+pub const ELECT_PRECONFER_PATH: &str = "/elect_preconfer";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExtraConfig {


### PR DESCRIPTION
```
ERROR Failed election: error sending request for url (http://abc.xyz/eth/v1/builder/eth/v1/builder/elect_preconfer)ERROR Failed election: error sending request for url (http://abc.xyz/eth/v1/builder/eth/v1/builder/elect_preconfer)
```

Got the error message.
The path is not correct~!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the endpoint path for the `ELECT_PRECONFER_PATH` constant to improve application routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->