### PR TITLE
fix: bls key conversion

### DIFF
--- a/crates/preconfer/src/lookahead_fetcher.rs
+++ b/crates/preconfer/src/lookahead_fetcher.rs
@@ -210,3 +210,15 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bls_public_key_conversion() {
+        let pk = PublicKey::default();
+        let bls_pk = BlsPublicKey::try_from(pk.to_bytes().as_ref()).unwrap();
+        assert_eq!(pk.to_bytes().as_ref(), bls_pk.as_ref());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the method name from `initialze` to `initialize` for clarity and consistency.
- **Improvements**
	- Enhanced the public key serialization process in the LookaheadFetcher, refining how public keys are derived for better accuracy in comparisons.
	- Added new test cases to improve coverage and ensure the correctness of public key conversion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->