### PR TITLE
chore: fix taiyi-cli naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ignored = ["alloy-contract", "tiny-bip39", "derive_more", "tree_hash", "ssz_rs",
 
 [workspace.dependencies]
 taiyi-preconfer = { path = "crates/preconfer" }
-taiyi-cli = { path = "crates/cli" }
+taiyi-cmd = { path = "crates/cli" }
 taiyi-primitives = { path = "crates/primitives" }
 taiyi-integration-tests = { path = "tests" }
 

--- a/bin/taiyi-cli/Cargo.toml
+++ b/bin/taiyi-cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "taiyi-utils"
+name = "taiyi-cli"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 clap = { workspace = true }
 eyre = { workspace = true }
-taiyi-cli = { workspace = true }
+taiyi-cmd = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tree_hash = { workspace = true }
 

--- a/bin/taiyi-cli/src/main.rs
+++ b/bin/taiyi-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use taiyi_cli::{initialize_tracing_log, DepositCommand};
+use taiyi_cmd::{initialize_tracing_log, DepositCommand};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about = "taiyi-cli", long_about = None)]

--- a/bin/taiyi/Cargo.toml
+++ b/bin/taiyi/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 [dependencies]
 clap = { workspace = true }
 eyre = { workspace = true }
-taiyi-cli = { workspace = true }
+taiyi-cmd = { workspace = true }
 tokio = { workspace = true }
 
 [[bin]]

--- a/bin/taiyi/src/main.rs
+++ b/bin/taiyi/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use taiyi_cli::{initialize_tracing_log, PreconferCommand};
+use taiyi_cmd::{initialize_tracing_log, PreconferCommand};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about = "taiyi", long_about = None)]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taiyi-cli"
+name = "taiyi-cmd"
 version = { workspace = true }
 edition = { workspace = true }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated naming convention for the command-line interface, now referred to as `taiyi-cmd`.
  
- **Bug Fixes**
	- Adjusted import paths to reflect the new dependency name, ensuring proper functionality of the command-line interface.

- **Chores**
	- Maintained existing workspace configurations and dependencies while updating package names for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->