### PR TITLE
feat: restrict parked & pending subpools

### DIFF
--- a/crates/preconfer/src/preconf_pool/mod.rs
+++ b/crates/preconfer/src/preconf_pool/mod.rs
@@ -58,9 +58,13 @@ impl PreconfPool {
         }
     }
 
-    pub fn request_inclusion(&self, preconf_req: PreconfRequest) -> Result<PoolState, PoolError> {
+    pub fn request_inclusion(
+        &self,
+        preconf_req: PreconfRequest,
+        chain_id: u64,
+    ) -> Result<PoolState, PoolError> {
         // validate the preconf request
-        let validation_outcome = self.validator.validate(&preconf_req);
+        let validation_outcome = self.validator.validate(&preconf_req, chain_id);
 
         match validation_outcome {
             ValidationOutcome::Valid { simulate, preconf_hash } => {

--- a/crates/preconfer/src/validator/mod.rs
+++ b/crates/preconfer/src/validator/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![allow(unused)]
 
+use alloy_primitives::U256;
 use reth_revm::primitives::EnvKzgSettings;
 use taiyi_primitives::{PreconfHash, PreconfRequest};
 
@@ -30,9 +31,15 @@ impl PreconfValidator {
         Self { block_gas_limit, minimum_prepay_fee, kzg_settings, max_tx_input_bytes }
     }
 
-    pub(crate) fn validate(&self, _preconf_req: &PreconfRequest) -> ValidationOutcome {
-        // Validate the transaction
-        todo!()
+    pub(crate) fn validate(
+        &self,
+        preconf_req: &PreconfRequest,
+        chain_id: u64,
+    ) -> ValidationOutcome {
+        ValidationOutcome::Valid {
+            simulate: true,
+            preconf_hash: preconf_req.hash(U256::from(chain_id)),
+        }
     }
 }
 


### PR DESCRIPTION
Restricts the user to:
1. target_slot must be the next slot ie. current_slot + 1
2. Send PreconfTx along with TipTx

Note: It is assumed that there're no other requests from the same user in a single slot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for preconf requests and transactions, ensuring more robust error handling and feedback.
	- Introduced a method to retrieve the chain ID, improving code organization.
	
- **Bug Fixes**
	- Improved error messages for validation failures to provide clearer feedback to users.

- **Refactor**
	- Updated method signatures to include chain ID for better validation logic in preconf operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->