### PR TITLE
chore: make command line args consistent

### DIFF
--- a/crates/cli/src/commands/batch_register.rs
+++ b/crates/cli/src/commands/batch_register.rs
@@ -12,18 +12,18 @@ use ProposerRegistry::ProposerRegistryInstance;
 #[derive(Debug, Parser)]
 pub struct BatchRegisterCommand {
     /// rpc url
-    #[clap(long = "rpc_url")]
-    pub rpc_url: String,
+    #[clap(long, env = "EXECUTION_RPC_URL")]
+    pub execution_rpc_url: String,
 
     /// Private key in hex format
-    #[clap(long = "private_key")]
+    #[clap(long, env = "PRIVATE_KEY")]
     pub private_key: String,
 
     /// taiyi proposer registry contract address
-    #[clap(long = "taiyi_proposer_registry_contract_addr")]
+    #[clap(long, env = "TAIYI_PROPOSER_REGISTRY_CONTRACT_ADDR")]
     pub taiyi_proposer_registry_contract_addr: String,
 
-    #[clap(long = "proposer_pubkeys", value_delimiter = ',')]
+    #[clap(long, env = "PROPOSER_PUBKEYS")]
     pub proposer_pubkey: Vec<String>,
 }
 
@@ -50,7 +50,7 @@ impl BatchRegisterCommand {
         let provider = ProviderBuilder::new()
             .with_recommended_fillers()
             .wallet(EthereumWallet::new(signer.clone()))
-            .on_builtin(&self.rpc_url)
+            .on_builtin(&self.execution_rpc_url)
             .await?;
 
         let chain_id = provider.get_chain_id().await?;

--- a/crates/cli/src/commands/get_validator.rs
+++ b/crates/cli/src/commands/get_validator.rs
@@ -10,14 +10,14 @@ use ProposerRegistry::ProposerRegistryInstance;
 #[derive(Debug, Parser)]
 pub struct GetValidatorCommand {
     /// rpc url
-    #[clap(long = "rpc_url")]
-    pub rpc_url: String,
+    #[clap(long, env = "EXECUTION_RPC_URL")]
+    pub execution_rpc_url: String,
 
     /// proposer registry contract address
-    #[clap(long = "proposer_registry_address")]
+    #[clap(long, env = "PROPOSER_REGISTRY_ADDRESS")]
     pub proposer_registry_address: String,
 
-    #[clap(long = "proposer_pubkey")]
+    #[clap(long, env = "PROPOSER_PUBKEY")]
     pub proposer_pubkey: String,
 }
 
@@ -48,8 +48,10 @@ sol! {
 impl GetValidatorCommand {
     pub async fn execute(&self) -> eyre::Result<()> {
         // Connect to the Ethereum network
-        let provider =
-            ProviderBuilder::new().with_recommended_fillers().on_builtin(&self.rpc_url).await?;
+        let provider = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .on_builtin(&self.execution_rpc_url)
+            .await?;
 
         let proposer_registry_address: Address = self.proposer_registry_address.parse()?;
         // Parse contract address

--- a/crates/cli/src/commands/preconfer.rs
+++ b/crates/cli/src/commands/preconfer.rs
@@ -6,35 +6,35 @@ use taiyi_preconfer::{metrics::preconfer::init_metrics, spawn_service};
 #[derive(Debug, Parser)]
 pub struct PreconferCommand {
     /// jsonrpc service address to listen on.
-    #[clap(long = "taiyi_rpc_addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    #[clap(long, env="TAIYI_RPC_ADDR", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub taiyi_rpc_addr: IpAddr,
 
     /// jsonrpc service port to listen on.
-    #[clap(long = "taiyi_rpc_port", default_value_t = 5656)]
+    #[clap(long, env = "TAIYI_RPC_PORT", default_value_t = 5656)]
     pub taiyi_rpc_port: u16,
 
     /// execution client rpc url
-    #[clap(long = "execution_client_url")]
-    pub execution_client_url: String,
+    #[clap(long, env = "EXECUTION_RPC_URL")]
+    pub execution_rpc_url: String,
 
     /// consensus client rpc url
-    #[clap(long = "beacon_client_url")]
-    pub beacon_client_url: String,
+    #[clap(long, env = "BEACON_RPC_URL")]
+    pub beacon_rpc_url: String,
 
     /// A BLS private key to use for signing
-    #[clap(long = "bls_sk")]
+    #[clap(long, env = "TAIYI_BLS_SK")]
     pub bls_sk: String,
 
     /// A BLS private key to use for signing
-    #[clap(long = "ecdsa_sk")]
+    #[clap(long, env = "TAIYI_ECDSA_SK")]
     pub ecdsa_sk: String,
 
     /// network
-    #[clap(long = "network")]
+    #[clap(long, env = "NETWORK")]
     pub network: String,
 
     /// consensus client rpc url
-    #[clap(long = "relay_url", value_delimiter = ',')]
+    #[clap(long, value_delimiter = ',')]
     pub relay_url: Vec<String>,
 
     /// taiyi service url. Internal usage for taiyi base fee predict module
@@ -58,8 +58,8 @@ impl PreconferCommand {
         let relay_url = self.relay_url.iter().map(|url| url.parse().expect("relay urls")).collect();
 
         spawn_service(
-            self.execution_client_url.clone(),
-            self.beacon_client_url.clone(),
+            self.execution_rpc_url.clone(),
+            self.beacon_rpc_url.clone(),
             context,
             self.taiyi_rpc_addr,
             self.taiyi_rpc_port,

--- a/crates/cli/src/commands/register.rs
+++ b/crates/cli/src/commands/register.rs
@@ -12,18 +12,18 @@ use ProposerRegistry::ProposerRegistryInstance;
 #[derive(Debug, Parser)]
 pub struct RegisterCommand {
     /// rpc url
-    #[clap(long = "rpc_url")]
-    pub rpc_url: String,
+    #[clap(long, env = "EXECUTION_RPC_URL")]
+    pub execution_rpc_url: String,
 
     /// Private key in hex format
-    #[clap(long = "private_key")]
+    #[clap(long, env = "PRIVATE_KEY")]
     pub private_key: String,
 
     /// taiyi proposer registry contract address
-    #[clap(long = "taiyi_proposer_registry_contract_addr")]
+    #[clap(long, env = "TAIYI_PROPOSER_REGISTRY_CONTRACT_ADDR")]
     pub taiyi_proposer_registry_contract_addr: String,
 
-    #[clap(long = "proposer_pubkey")]
+    #[clap(long, env = "PROPOSER_PUBKEY")]
     pub proposer_pubkey: String,
 }
 
@@ -44,7 +44,7 @@ impl RegisterCommand {
         let provider = ProviderBuilder::new()
             .with_recommended_fillers()
             .wallet(EthereumWallet::new(signer.clone()))
-            .on_builtin(&self.rpc_url)
+            .on_builtin(&self.execution_rpc_url)
             .await?;
 
         // Parse contract address

--- a/crates/preconfer/src/lookahead_fetcher.rs
+++ b/crates/preconfer/src/lookahead_fetcher.rs
@@ -33,7 +33,7 @@ pub struct LookaheadFetcher {
 
 impl LookaheadFetcher {
     pub fn new(
-        beacon_url: String,
+        beacon_rpc_url: String,
         network_state: NetworkState,
         gateway_pubkey: PublicKey,
         relay_urls: Vec<Url>,
@@ -41,7 +41,7 @@ impl LookaheadFetcher {
         let gateway_pubkey =
             BlsPublicKey::try_from(gateway_pubkey.to_bytes().as_ref()).expect("Invalid public key");
         Self {
-            beacon_client: Client::new(Url::parse(&beacon_url).expect("Invalid URL")),
+            beacon_client: Client::new(Url::parse(&beacon_rpc_url).expect("Invalid URL")),
             network_state,
             gateway_pubkey,
             relay_client: RelayClient::new(relay_urls),
@@ -121,12 +121,13 @@ impl LookaheadFetcher {
 }
 
 pub async fn run_cl_process(
-    beacon_url: String,
+    beacon_rpc_url: String,
     network_state: NetworkState,
     bls_pk: PublicKey,
     relay_urls: Vec<Url>,
 ) -> impl Future<Output = eyre::Result<()>> {
-    let lookahead_fetcher = LookaheadFetcher::new(beacon_url, network_state, bls_pk, relay_urls);
+    let lookahead_fetcher =
+        LookaheadFetcher::new(beacon_rpc_url, network_state, bls_pk, relay_urls);
     lookahead_fetcher.run()
 }
 

--- a/crates/preconfer/src/preconf_api/state.rs
+++ b/crates/preconfer/src/preconf_api/state.rs
@@ -45,7 +45,7 @@ pub struct PreconfState {
     network_state: NetworkState,
     preconf_pool: Arc<PreconfPool>,
     signer_client: SignerClient,
-    rpc_url: String,
+    execution_rpc_url: String,
 }
 
 impl PreconfState {
@@ -53,22 +53,22 @@ impl PreconfState {
         network_state: NetworkState,
         relay_client: RelayClient,
         signer_client: SignerClient,
-        rpc_url: String,
+        execution_rpc_url: String,
     ) -> Self {
         let slot = network_state.get_current_slot();
         let preconf_pool = PreconfPoolBuilder::new().build(slot);
 
-        Self { relay_client, network_state, preconf_pool, signer_client, rpc_url }
+        Self { relay_client, network_state, preconf_pool, signer_client, execution_rpc_url }
     }
 
     pub fn execution_api_client(&self) -> eyre::Result<RootProvider<Http<Client>>> {
-        let rpc = self.rpc_url.parse()?;
+        let rpc = self.execution_rpc_url.parse()?;
         let provider = ProviderBuilder::new().on_http(rpc);
         Ok(provider)
     }
 
     pub fn rpc_client(&self) -> eyre::Result<RpcClient<Http<Client>>> {
-        let rpc = self.rpc_url.parse()?;
+        let rpc = self.execution_rpc_url.parse()?;
         let client = ClientBuilder::default().http(rpc);
         Ok(client)
     }
@@ -187,7 +187,7 @@ impl PreconfState {
 
         match self
             .preconf_pool
-            .request_inclusion(preconf_request.clone(), request_id, self.rpc_url.clone())
+            .request_inclusion(preconf_request.clone(), request_id, self.execution_rpc_url.clone())
             .await
         {
             Ok(PoolType::Ready) | Ok(PoolType::Pending) => {
@@ -243,7 +243,7 @@ impl PreconfState {
 
         match self
             .preconf_pool
-            .request_inclusion(preconf_request.clone(), request_id, self.rpc_url.clone())
+            .request_inclusion(preconf_request.clone(), request_id, self.execution_rpc_url.clone())
             .await
         {
             Ok(PoolType::Ready) | Ok(PoolType::Pending) => {

--- a/e2e-tests/src/utils.rs
+++ b/e2e-tests/src/utils.rs
@@ -115,19 +115,19 @@ pub async fn start_taiyi_command_for_testing(
     // Create a default instance of the main command or configure it as needed
     let taiyi_command = PreconferCommand::parse_from([
         "preconfer",
-        "--bls_sk",
+        "--bls-sk",
         PRECONFER_BLS_SK,
-        "--ecdsa_sk",
+        "--ecdsa-sk",
         PRECONFER_ECDSA_SK,
         "--network",
         &network_dir,
-        "--execution_client_url",
+        "--execution-rpc-url",
         &config.execution_url,
-        "--beacon_client_url",
+        "--beacon-rpc-url",
         &config.beacon_url,
-        "--relay_url",
+        "--relay-url",
         &config.relay_url,
-        "--taiyi_rpc_port",
+        "--taiyi-rpc-port",
         config.taiyi_port.to_string().as_str(),
     ]); // Assuming TaiyiCommand is the main command struct
 


### PR DESCRIPTION
Currently the command args some are using "-" and some are using "_" as separator. I am changing to use "-" for all to create better user experience.

Also rename execution_client_url to execution_rpc_url and beacon_client_url to beacon_rpc_url