### PR TITLE
docs: update dead link

### DIFF
--- a/docs/node_operator_setup_guide/holesky/onchain_registration.mdx
+++ b/docs/node_operator_setup_guide/holesky/onchain_registration.mdx
@@ -103,7 +103,7 @@ For additional key source options and detailed usage of the delegate command, se
 
 
 
-This step follows the `/constraints/v0/builder/delegate` endpoint specification from the [Preconfirmations API](https://github.com/ethereum-commitments/constraints-specs/blob/main/specs/preconf-api.md#endpoint-constraintsv0builderdelegate) to perform the underwriter delegation. The process involves:
+This step follows the `/constraints/v0/builder/delegate` endpoint specification from the [Preconfirmations API](https://github.com/eth-fabric/constraints-specs/blob/main/specs/constraints-api.md#endpoint-constraintsv0builderdelegate) to perform the underwriter delegation. The process involves:
 
 1. Proposer (your validator) electing the Underwriter through delegation
 2. Underwriter managing preconfirmation constraints


### PR DESCRIPTION
Hi! I fixed a broken link to the `/constraints/v0/builder/delegate` endpoint specification.