### PR TITLE
Fix preconf fee input validation in `submit_transaction_type_b`

### DIFF
--- a/bin/taiyi-boost/src/constraints.rs
+++ b/bin/taiyi-boost/src/constraints.rs
@@ -64,7 +64,7 @@ mod tests {
     #[tokio::test]
     async fn test_constraints_cache() -> eyre::Result<()> {
         let raw_sk = "0x84286521b97e7c10916857c307553e30a9defd100e893e96fc8aad42336a4ab3";
-        let hex_sk = raw_sk.strip_prefix("0x").unwrap_or(&raw_sk);
+        let hex_sk = raw_sk.strip_prefix("0x").unwrap_or(raw_sk);
 
         let sk = SigningKey::from_slice(hex::decode(hex_sk)?.as_slice())?;
         let signer = PrivateKeySigner::from_signing_key(sk.clone());

--- a/crates/primitives/src/preconf_fee.rs
+++ b/crates/primitives/src/preconf_fee.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 
 /// Gas prices in WEI
 pub struct PreconfFeeResponse {

--- a/crates/primitives/src/preconf_request_type_b.rs
+++ b/crates/primitives/src/preconf_request_type_b.rs
@@ -5,6 +5,8 @@ use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::PreconfFeeResponse;
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PreconfRequestTypeB {
     /// blockspace allocated
@@ -79,6 +81,8 @@ pub struct BlockspaceAllocation {
     pub target_slot: u64,
     /// Number of blobs to reserve
     pub blob_count: usize,
+    /// Gas fees quoted by the underwriter for the transaction
+    pub preconf_fee: PreconfFeeResponse,
 }
 
 impl BlockspaceAllocation {

--- a/crates/underwriter/src/preconf_api/state.rs
+++ b/crates/underwriter/src/preconf_api/state.rs
@@ -141,7 +141,7 @@ where
 
         preconf_request.transaction = Some(request.transaction.clone());
 
-        let preconf_fee = self.pricer.pricer.get_preconf_fee(preconf_request.target_slot()).await?;
+        let preconf_fee = preconf_request.allocation.preconf_fee.clone();
         match self
             .preconf_pool
             .validate_and_store(

--- a/crates/underwriter/src/tests.rs
+++ b/crates/underwriter/src/tests.rs
@@ -210,6 +210,7 @@ async fn generate_reserve_blockspace_request(
         tip: U256::from(fee * 21_000 / 2),
         gas_limit: 21_000,
         blob_count: 0,
+        preconf_fee,
     };
     let signature =
         hex::encode(signer.sign_hash(&request.hash(chain_id)).await.unwrap().as_bytes());

--- a/e2e-tests/src/test_preconf_workflow.rs
+++ b/e2e-tests/src/test_preconf_workflow.rs
@@ -379,7 +379,8 @@ async fn test_type_a_preconf_request() -> eyre::Result<()> {
 
     // Generate request and signature
     let (request, signature) =
-        generate_type_a_request(signer.clone(), target_slot, &config.execution_url, fee).await?;
+        generate_type_a_request(signer.clone(), target_slot, &config.execution_url, fee.clone())
+            .await?;
 
     info!("Submitting request for target slot: {:?}", target_slot);
     info!("tip tx: {:?}", request.tip_transaction.tx_hash());

--- a/e2e-tests/src/utils.rs
+++ b/e2e-tests/src/utils.rs
@@ -360,11 +360,11 @@ pub async fn generate_reserve_blockspace_request(
     target_slot: u64,
     gas_limit: u64,
     blob_count: u64,
-    preocnf_fee: PreconfFeeResponse,
+    preconf_fee: PreconfFeeResponse,
     chain_id: u64,
 ) -> (BlockspaceAlloc, String) {
-    let fee = preocnf_fee.gas_fee * (gas_limit as u128)
-        + preocnf_fee.blob_gas_fee * ((blob_count * DATA_GAS_PER_BLOB) as u128);
+    let fee = preconf_fee.gas_fee * (gas_limit as u128)
+        + preconf_fee.blob_gas_fee * ((blob_count * DATA_GAS_PER_BLOB) as u128);
     let fee = U256::from(fee / 2);
     let recepient = UNDERWRITER_ECDSA_SK.parse::<PrivateKeySigner>().unwrap();
     let request = BlockspaceAlloc {
@@ -375,6 +375,7 @@ pub async fn generate_reserve_blockspace_request(
         tip: fee,
         gas_limit,
         blob_count: blob_count.try_into().unwrap(),
+        preconf_fee,
     };
     info!("block space allocation request: {:?}", request);
     let signature =

--- a/examples/type_b/src/main.rs
+++ b/examples/type_b/src/main.rs
@@ -114,6 +114,7 @@ async fn main() -> eyre::Result<()> {
         tip: fee,
         gas_limit,
         blob_count: blob_count.try_into().unwrap(),
+        preconf_fee,
     };
     let x_luban_sig_header = format!(
         "0x{}",

--- a/spammer/src/http.rs
+++ b/spammer/src/http.rs
@@ -68,6 +68,7 @@ impl HttpClient {
             tip: fee,
             gas_limit,
             blob_count: blob_count.try_into().unwrap(),
+            preconf_fee,
         };
         let signature = hex::encode(
             self.signer.sign_hash(&blockspace_data.hash(self.chain_id)).await.unwrap().as_bytes(),


### PR DESCRIPTION
Handles #611 / TAI-127

Key change is adding a `preconf_fee: PreconfFeeResponse` field inside `BlockspaceAllocation`. This way, the quoted price is stored in the state together with the `PreconfRequestTypeB`, and it is accessible inside `submit_transaction_type_b` via `preconf_request.allocation.preconf_fee`.

As a side effect, the commitment stream now publishes the quoted preconf fee for type B transactions. I could make this more symmetrical by introducing a `preconf_fee` field in the `struct PreconfRequestTypeB`, since in #608 i am also going to need this info for type A transactions. I wasn't sure whether to introduce this change in this PR because it isn't directly related to the bugfix, let me know.

additionally, fixed a couple of clippy warnings