### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             cp target/${{ matrix.target }}/release/taiyi-cli release/taiyi-cli-${{ matrix.target }}
           fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: taiyi-${{ github.sha }}
           path: release/*
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: taiyi-${{ github.sha }}
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  unit-tests:
-    uses: lu-bann/taiyi/.github/workflows/ci.yml@dev
-
-  e2e-tests:
-    uses: lu-bann/taiyi/.github/workflows/e2e-tests.yml@dev
-
   docker:
     name: Build and Push Docker Image
     needs: [unit-tests, e2e-tests]


### PR DESCRIPTION
The release ci failed because of artifact version is too old.
https://github.com/lu-bann/taiyi/actions/runs/14016130389

Also exclude tests in releasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated versions of GitHub Actions for uploading and downloading artifacts.
- **Refactor**
  - Removed certain testing steps from the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->