### PR TITLE
chore: derive `PartialEq` in `EstimateBaseFeeQuery`

### DIFF
--- a/crates/underwriter/src/clients/pricer.rs
+++ b/crates/underwriter/src/clients/pricer.rs
@@ -25,7 +25,7 @@ pub struct EstimateBaseFeeResponse {
     pub blob_base_fee: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct EstimateBaseFeeQuery {
     pub block_number: i64,
 }


### PR DESCRIPTION
again, for better testing. 

just realized that in the previous PR #670 I mis-typed the object of the change: in fact it was actually `EstimateBaseFeeResponse`, sorry about that. 

This PR changes the actual `EstimateBaseFeeQuery`.