### PR TITLE
remove linglong repo folder in clean.sh (make e2e-clean)

### DIFF
--- a/scripts/devnet/clean.sh
+++ b/scripts/devnet/clean.sh
@@ -2,6 +2,8 @@ set -xe
 
 source "$(dirname "$0")/config.sh"
 
+# `|| true` ignore error to continue even if we did `set -e`
+rm -rf linglong || true
 kurtosis enclave rm -f $ENCLAVE_NAME
 pushd $WORKING_DIR
 rm -rf 1-lighthouse-geth-0-63

--- a/scripts/devnet/initialize.sh
+++ b/scripts/devnet/initialize.sh
@@ -14,10 +14,9 @@ popd
 
 # TAIYI propser registry would be 0x0A79920c296E86e7BB12Ad20ca7Ffbbd7AE5905B
 # TAIYI CORE would be 0xA791D59427B2b7063050187769AC871B497F4b3C
-[ -d "linglong" ] || git clone https://github.com/lu-bann/linglong --recursive --jobs 8
+# make e2e-clean will REMOVE this folder as it is only needed for e2e testing
+[ -d "linglong" ] || git clone https://github.com/lu-bann/linglong --recursive --jobs 8 --depth 1
 pushd linglong
-git pull
-git submodule update --recursive --init
 bash script/deploy.sh
 bash script/setup-contract.sh
 popd


### PR DESCRIPTION
since linglong is not a submodule anymore, and is only used in e2e testing, it makes sense to remove it in `make e2e-clean`.

this commit also adds `--depth 1` to the `git clone` command to perform a shallow clone, can be quicker than an ordinary clone.
