### PR TITLE
e2e test misc fixes

### DIFF
--- a/crates/underwriter/src/account_state.rs
+++ b/crates/underwriter/src/account_state.rs
@@ -10,9 +10,6 @@ use tracing::error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum AccountError {
-    #[error("Failed to query account for {owner}")]
-    FailedQuery { owner: Address },
-
     #[error("Balance too low (balance={balance}, required={required})")]
     BalanceTooLow { balance: U256, required: U256 },
 

--- a/crates/underwriter/src/api.rs
+++ b/crates/underwriter/src/api.rs
@@ -38,6 +38,7 @@ use tracing::{error, info};
 use url::Url;
 use uuid::Uuid;
 
+use crate::account_state;
 use crate::{
     account_info::OnChainAccountInfoProvider,
     account_state::AccountState,
@@ -152,8 +153,15 @@ pub enum PreconfApiError {
 
 impl IntoResponse for PreconfApiError {
     fn into_response(self) -> Response {
+        let status_code = match &self {
+            PreconfApiError::Account(account_state::AccountError::BalanceTooLow {
+                balance: _,
+                required: _,
+            }) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
         let message = self.to_string();
-        (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+        (status_code, message).into_response()
     }
 }
 

--- a/crates/underwriter/src/event_stream.rs
+++ b/crates/underwriter/src/event_stream.rs
@@ -153,7 +153,7 @@ pub async fn process_event_stream<F: EventHandler>(
             match f.handle_event(head).await {
                 Ok(_) => debug!("finished processing event: {}", text),
                 Err(e) => {
-                    error!("error processing event: {e}");
+                    error!("error processing event: {e}. Event was {text}");
                     continue;
                 }
             }

--- a/e2e-tests/src/test_preconf_workflow.rs
+++ b/e2e-tests/src/test_preconf_workflow.rs
@@ -218,9 +218,9 @@ async fn test_reserve_blockspace_invalid_insufficient_balance() -> eyre::Result<
     let status = res.status();
     let body = res.bytes().await?;
     info!("reserve_blockspace response: {:?}", body);
-    let response = serde_json::from_slice::<ErrorResponse>(&body)?;
     assert_eq!(status, 400);
-    assert!(response.message.contains("InsufficientEscrowBalance"));
+    let response = serde_json::from_slice::<String>(&body)?;
+    assert!(response.contains("Balance too low"));
     drop(taiyi_handle);
     Ok(())
 }

--- a/e2e-tests/src/test_preconf_workflow.rs
+++ b/e2e-tests/src/test_preconf_workflow.rs
@@ -23,7 +23,7 @@ use crate::{
         generate_reserve_blockspace_request, generate_submit_transaction_request, generate_tx,
         generate_tx_with_nonce, generate_type_a_request, generate_type_a_request_with_nonce,
         getTipCall, get_available_slot, get_block_from_slot, get_constraints_from_relay,
-        get_preconf_fee, health_check, new_account, send_reserve_blockspace_request,
+        get_preconf_fee, health_check, new_random_account, send_reserve_blockspace_request,
         send_submit_transaction_request, send_type_a_request, setup_env, verify_tx_in_block,
         verify_txs_inclusion, wait_until_deadline_of_slot, ErrorResponse,
     },
@@ -60,7 +60,7 @@ async fn test_type_b_preconf_request() -> eyre::Result<()> {
     // Start taiyi command in background
     let (taiyi_handle, config) = setup_env().await?;
 
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(signer.clone()))
@@ -69,7 +69,7 @@ async fn test_type_b_preconf_request() -> eyre::Result<()> {
     info!("type b preconf request");
     let chain_id = provider.get_chain_id().await?;
 
-    // Deposit 1ether to TaiyiCore
+    // Deposit ether to TaiyiCore
     taiyi_deposit(provider.clone(), 5 * ETH_TO_WEI, &config).await?;
 
     let balance = taiyi_balance(provider.clone(), signer.address(), &config).await?;
@@ -192,7 +192,7 @@ async fn test_type_b_preconf_request() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_reserve_blockspace_invalid_insufficient_balance() -> eyre::Result<()> {
     let (taiyi_handle, config) = setup_env().await?;
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let wallet = EthereumWallet::new(signer.clone());
     let provider = ProviderBuilder::new()
@@ -228,7 +228,7 @@ async fn test_reserve_blockspace_invalid_insufficient_balance() -> eyre::Result<
 #[tokio::test]
 async fn test_reserve_blockspace_invalid_reverter() -> eyre::Result<()> {
     let (taiyi_handle, config) = setup_env().await?;
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let wallet = EthereumWallet::new(signer.clone());
     let provider = ProviderBuilder::new()
@@ -275,7 +275,7 @@ async fn test_reserve_blockspace_invalid_reverter() -> eyre::Result<()> {
     info!("submit transaction response: {:?}", body);
     let preconf_response: PreconfResponseData = serde_json::from_slice(&body)?;
     // CUrrently revert tx is not rejected.
-    assert_eq!(status, 200);
+    assert_eq!(status, 200, "status not OK: {preconf_response:?}");
     assert_eq!(preconf_response.request_id, request_id);
     drop(taiyi_handle);
     Ok(())
@@ -285,14 +285,14 @@ async fn test_reserve_blockspace_invalid_reverter() -> eyre::Result<()> {
 async fn test_exhaust_is_called_for_requests_without_preconf_txs() -> eyre::Result<()> {
     // Start taiyi command in background
     let (_taiyi_handle, config) = setup_env().await?;
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(signer.clone()))
         .connect_http(Url::from_str(&config.execution_url)?);
     let chain_id = provider.get_chain_id().await?;
 
-    // Deposit 1ether to TaiyiCore
+    // Deposit ether to TaiyiCore
     taiyi_deposit(provider.clone(), 5 * ETH_TO_WEI, &config).await?;
     let balance = taiyi_balance(provider.clone(), signer.address(), &config).await?;
     assert_eq!(balance, U256::from(5 * ETH_TO_WEI));
@@ -367,12 +367,15 @@ async fn test_exhaust_is_called_for_requests_without_preconf_txs() -> eyre::Resu
 async fn test_type_a_preconf_request() -> eyre::Result<()> {
     // Start taiyi command in background
     let (taiyi_handle, config) = setup_env().await?;
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(signer.clone()))
         .connect_http(Url::from_str(&config.execution_url)?);
     let chain_id = provider.get_chain_id().await?;
+
+    // Deposit 5ether to TaiyiCore
+    taiyi_deposit(provider.clone(), 5 * ETH_TO_WEI, &config).await?;
 
     // Pick a slot from the lookahead
     let available_slot = get_available_slot(&config.taiyi_url()).await?;
@@ -467,8 +470,26 @@ async fn test_send_multiple_type_a_preconf_for_the_same_slot() -> eyre::Result<(
     let (taiyi_handle, config) = setup_env().await?;
 
     // Create two different users
-    let user1 = new_account(&config).await?;
-    let user2 = new_account(&config).await?;
+    let user1 = new_random_account(&config).await?;
+    let user2 = new_random_account(&config).await?;
+
+    // Deposit ether to TaiyiCore
+    taiyi_deposit(
+        ProviderBuilder::new()
+            .wallet(EthereumWallet::new(user1.clone()))
+            .connect_http(Url::from_str(&config.execution_url)?),
+        5 * ETH_TO_WEI,
+        &config,
+    )
+    .await?;
+    taiyi_deposit(
+        ProviderBuilder::new()
+            .wallet(EthereumWallet::new(user2.clone()))
+            .connect_http(Url::from_str(&config.execution_url)?),
+        5 * ETH_TO_WEI,
+        &config,
+    )
+    .await?;
 
     // Pick a slot from the lookahead
     let available_slot = get_available_slot(&config.taiyi_url()).await?;
@@ -598,14 +619,14 @@ async fn test_send_multiple_type_a_preconf_for_the_same_slot() -> eyre::Result<(
 async fn test_type_a_and_type_b_requests() -> eyre::Result<()> {
     // Start taiyi command in background
     let (taiyi_handle, config) = setup_env().await?;
-    let signer = new_account(&config).await?;
+    let signer = new_random_account(&config).await?;
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(signer.clone()))
         .connect_http(Url::from_str(&config.execution_url)?);
     let chain_id = provider.get_chain_id().await?;
 
-    // Deposit 1ether to TaiyiCore
+    // Deposit ether to TaiyiCore
     taiyi_deposit(provider.clone(), 5 * ETH_TO_WEI, &config).await?;
 
     let balance = taiyi_balance(provider.clone(), signer.address(), &config).await?;

--- a/e2e-tests/src/test_preconf_workflow.rs
+++ b/e2e-tests/src/test_preconf_workflow.rs
@@ -25,7 +25,7 @@ use crate::{
         getTipCall, get_available_slot, get_block_from_slot, get_constraints_from_relay,
         get_preconf_fee, health_check, new_random_account, send_reserve_blockspace_request,
         send_submit_transaction_request, send_type_a_request, setup_env, verify_tx_in_block,
-        verify_txs_inclusion, wait_until_deadline_of_slot, ErrorResponse,
+        verify_txs_inclusion, wait_until_deadline_of_slot,
     },
 };
 
@@ -217,10 +217,9 @@ async fn test_reserve_blockspace_invalid_insufficient_balance() -> eyre::Result<
     let res = send_reserve_blockspace_request(request, signature, &config.taiyi_url()).await?;
     let status = res.status();
     let body = res.bytes().await?;
-    info!("reserve_blockspace response: {:?}", body);
+    info!("reserve_blockspace response: status {status}, body: {:?}", body);
     assert_eq!(status, 400);
-    let response = serde_json::from_slice::<String>(&body)?;
-    assert!(response.contains("Balance too low"));
+    assert!(String::from_utf8(body.to_vec())?.contains("Balance too low"));
     drop(taiyi_handle);
     Ok(())
 }

--- a/e2e-tests/src/utils.rs
+++ b/e2e-tests/src/utils.rs
@@ -624,7 +624,7 @@ pub async fn new_random_account(config: &TestConfig) -> eyre::Result<PrivateKeyS
     tx.set_to(new_signer.address());
     tx.set_value(U256::from(10 * ETH_TO_WEI));
     let send = provider.send_transaction(tx).await?;
-    let _ = send.with_required_confirmations(1).get_receipt().await?;
+    let _ = send.get_receipt().await?;
     assert!(
         provider.get_balance(new_signer.address()).await? >= U256::from(10 * ETH_TO_WEI),
         "new signer didn't get enough ETH"


### PR DESCRIPTION
some more effort into making the e2e tests pass
- Some tests were failing due to "insufficient balance": i added code to deposit ether into taiyi. Now they are failing due to invalid nonce.
- rename new_account -> new_random_account. Sounds more self-explanatory.
- In `test_reserve_blockspace_invalid_insufficient_balance`, we did `assert_eq(status_code, 400)`. But in the `IntoResponse` implementation of `PreconfApiError`, we always return HTTP 500 Internal Error. Added a special case for `PreconfApiError::Account(AccountError::BalanceTooLow)` which returns 400. We should determine HTTP status codes more clearly: either all errors use the same code, or we use them properly.
- restored original behaviour by returning 400 Bad Request on BalanceTooLow error
- more verbose error logging in event_stream: log the message which caused the error.

