### PR TITLE
fix: sender channel drop too early

### DIFF
--- a/crates/underwriter/src/broadcast_sender.rs
+++ b/crates/underwriter/src/broadcast_sender.rs
@@ -32,8 +32,13 @@ pub struct BroadcastSender {
 }
 
 impl BroadcastSender {
-    pub fn new(signer: PrivateKeySigner, chain_id: u64, last_slot: Arc<AtomicU64>) -> Self {
-        Self { signer, chain_id, last_slot, broadcast_sender: broadcast::channel(128).0 }
+    pub fn new(
+        signer: PrivateKeySigner,
+        chain_id: u64,
+        last_slot: Arc<AtomicU64>,
+        sender: broadcast::Sender<(PreconfRequest, PreconfResponseData)>,
+    ) -> Self {
+        Self { signer, chain_id, last_slot, broadcast_sender: sender }
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<(PreconfRequest, PreconfResponseData)> {


### PR DESCRIPTION
The request would go wrong when it tries to broadcast preconf request because the channel is dropped right after it is created. 


error logs :
```
taiyi_e2e_tests::test_preconf_workflow: submit Type A request response: b"channel closed"
```