### PR TITLE
Fix spelling errors in code comments

### DIFF
--- a/crates/bls/src/impls/blst.rs
+++ b/crates/bls/src/impls/blst.rs
@@ -106,7 +106,7 @@ pub fn verify_signature_sets<'a>(
 
     // Public keys have already been checked for subgroup and infinity
     // Signatures have already been checked for subgroup
-    // Signature checks above could be done here for convienence as well
+    // Signature checks above could be done here for convenience as well
     let err = blst_core::Signature::verify_multiple_aggregate_signatures(
         &msgs_refs, DST, &pks_refs, false, &sig_refs, false, &rands, RAND_BITS,
     );

--- a/crates/eth2_keystore/src/keystore.rs
+++ b/crates/eth2_keystore/src/keystore.rs
@@ -491,7 +491,7 @@ fn validate_parameters(kdf: &Kdf) -> Result<(), Error> {
                 return Err(Error::InvalidPbkdf2Param);
             }
 
-            // NIST Recommends suggests potential use cases where `c` of 10,000,000 is desireable.
+            // NIST Recommends suggests potential use cases where `c` of 10,000,000 is desirable.
             // As it is 10 years old this has been increased to 80,000,000. Larger values will
             // take over 1 minute to execute on an average machine.
             //


### PR DESCRIPTION


## Description

This PR fixes minor spelling errors found in code comments across the codebase:

- **`crates/bls/src/impls/blst.rs`**: Fixed "convienence" → "convenience"
- **`crates/eth2_keystore/src/keystore.rs`**: Fixed "desireable" → "desirable"


