### PR TITLE
fix: typo in glossary.mdx

### DIFF
--- a/docs/learn/glossary.mdx
+++ b/docs/learn/glossary.mdx
@@ -8,7 +8,7 @@ icon: 'book'
 [Commit-Boost](https://github.com/Commit-Boost/commit-boost-client) is a proposer commitment side car that allows validators to make commitments to the block proposer.
 
 #### Commitment Deadline:
-This is a time limit set for accepting commitments to ensure they can be included and bordcasted to the block builders by the relay.
+This is a time limit set for accepting commitments to ensure they can be included and broadcast to the block builders by the relay.
 
 #### Epoch and Slot:
 These are time-based concepts in Ethereum. An epoch is a fixed period consisting of multiple slots, and a slot is a unit of time during which a block can be proposed. Through the documentation, otherwise separately noted, epoch and slots are defined according to the [consensus client spec](https://github.com/ethereum/consensus-specs). 


### PR DESCRIPTION
It should be "broadcast" instead of "bordcasted" because "broadcast" is the correct spelling and its past tense is the same as the base form, not "broadcasted"