### PR TITLE
makefile: run all tests in the workspace excluding taiyi-e2e-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 build:
 	cargo build --release
 
+# run all tests except the e2e ones which require environment setup
 test:
-	cargo test
+	cargo test --workspace --exclude taiyi-e2e-tests
 
 coverage:
-	cargo llvm-cov
+	cargo llvm-cov --workspace --exclude taiyi-e2e-tests
 
 coverage-report:
-	cargo llvm-cov --html
+	cargo llvm-cov --html --workspace --exclude taiyi-e2e-tests
 
 format:
 	cargo fmt --all


### PR DESCRIPTION
I noticed that not all unit tests were being executed with `make test` or `make coverage`, because those commands were running just `cargo test`. Added `--workspace --exclude taiyi-e2e-tests` to actually run everything.

When i ran the full command, i noticed that `test_reserve_slot_with_calldata` was failing, and this was not previously being detected by CI due to the above mentioned issue. The failure message is:

```
thread 'underwriter::tests::test_reserve_slot_with_calldata' panicked at crates/underwriter/src/preconf_signer.rs:7:18:
MockPreconfSigner::sign(TypeA(PreconfRequestTypeA { tip_transaction: Eip1559(Signed { tx: TxEip1559 { chain_id: 0, nonce: 0, gas_limit: 0, max_fee_per_gas: 0, max_priority_fee_per_gas: 0, to: Create, value: 0, access_list: AccessList([]), input: 0x }, signature: Signature { y_parity: false, r: 1, s: 0 }, hash: OnceLock(0x50d653959373bb7859c075f4b50225943af9625f5a0b08299c08341f0609c494) }), preconf_tx: [], target_slot: 10, sequence_number: Some(1), signer: 0xc6d4d821af5bb2543a5b3428681612c259d26b34, preconf_fee: PreconfFee { gas_fee: 10, blob_gas_fee: 150 } })): No matching expectation found
```
