### PR TITLE
ci: use `make test` to run tests rather than `make coverage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
         run: |
           make lint
       - name: Run tests
-        run: make coverage
+        run: make test
         if: ${{ always() }}


### PR DESCRIPTION
As the title says, in CI we run llvm-cov but then we don't use the results in any way, correct me if i'm wrong.

To save CI resources (avoid downloading llvm-cov, save disk space & computation time during compilation), I propose we just run `make test`.
