### PR TITLE
Fix typos in code comments

### DIFF
--- a/crates/cb-common/src/pbs/mev_boost/submit_block.rs
+++ b/crates/cb-common/src/pbs/mev_boost/submit_block.rs
@@ -181,7 +181,7 @@ async fn send_submit_block(
         }));
     }
 
-    // request has different type so cant be deserialized in the wrong version,
+    // request has different type so can't be deserialized in the wrong version,
     // response has a "version" field
     match (&signed_blinded_block.message, &block_response) {
         (

--- a/crates/cli/src/keys_management/pb/google.api.rs
+++ b/crates/cli/src/keys_management/pb/google.api.rs
@@ -9,7 +9,7 @@ pub struct Http {
     /// **NOTE:** All service configuration rules follow "last one wins" order.
     #[prost(message, repeated, tag = "1")]
     pub rules: ::prost::alloc::vec::Vec<HttpRule>,
-    /// When set to true, URL path parmeters will be fully URI-decoded except in
+    /// When set to true, URL path parameters will be fully URI-decoded except in
     /// cases of single segment matches in reserved expansion, where "%2F" will be
     /// left encoded.
     ///


### PR DESCRIPTION


This PR fixes minor typos in code comments across two files:


- **`crates/cb-common/src/pbs/mev_boost/submit_block.rs`**
  - fixed "cant" → "can't" 

- **`crates/cli/src/keys_management/pb/google.api.rs`**
  - fixed "parmeters" → "parameters" 

