### PR TITLE
docs: fix typos and grammar in fundamentals pages

### DIFF
--- a/docs/learn/fundamentals/pricing_preconf.mdx
+++ b/docs/learn/fundamentals/pricing_preconf.mdx
@@ -5,7 +5,7 @@ icon: 'dollar-sign'
 
 1. Taiyi pricing approach 
 
-At Luban we price the prefonfirmations with a data-driven approach tailored for the unique supply-demand dynamics of blockspace. While methods such as Black-Scholes options pricing are wildly recognized to form a basis of options-like derivatives pricing, assumptions on which they are formed are often not relevant to intricate flows of real markets.
+At Luban we price the prefonfirmations with a data-driven approach tailored for the unique supply-demand dynamics of blockspace. While methods such as Black-Scholes options pricing are widely recognized to form a basis of options-like derivatives pricing, assumptions on which they are formed are often not relevant to intricate flows of real markets.
 
 This is particularly pronounced in on-chain blockspace markets. Stabilizing gas prices for end users requires a multi-layered approach that considers both the base fee and tip fee, current block congestion, and eventually, mempool dynamics for intra-block pre-confirmations pricing.
 

--- a/docs/learn/fundamentals/what.mdx
+++ b/docs/learn/fundamentals/what.mdx
@@ -96,7 +96,7 @@ Taiyi significantly improves Ethereum's censorship resistance by decentralizing 
 </Accordion>
 
 <Accordion title="5. Reusable Validator Set For Based Rollups">
-Taiyi solves the cold start problem for based rollups by providing a reusable validator set. This allows new rollups to leverage Taiyi's existing network of validators, significantly reducing deployment time and costs. Built-in delegation mechanism allows validators to delegate L2 block building to "superbuilders" from day 1, significantly the time needed to provide optimal UX.
+Taiyi solves the cold start problem for based rollups by providing a reusable validator set. This allows new rollups to leverage Taiyi's existing network of validators, significantly reducing deployment time and costs. Built-in delegation mechanism allows validators to delegate L2 block building to "superbuilders" from day 1, significantly reducing the time needed to provide optimal UX.
 </Accordion>
 
 


### PR DESCRIPTION
- pricing_preconf.mdx: 
  - "wildly recognized" → "widely recognized"
- what.mdx:
  - "significantly the time needed" → "significantly reducing the time needed"