### PR TITLE
docs: fix typos in pricing fundamentals and node operator setup  

### DIFF
--- a/docs/learn/fundamentals/pricing_preconf.mdx
+++ b/docs/learn/fundamentals/pricing_preconf.mdx
@@ -5,7 +5,7 @@ icon: 'dollar-sign'
 
 1. Taiyi pricing approach 
 
-At Luban we price the prefonfirmations with a data-driven approach tailored for the unique supply-demand dynamics of blockspace. While methods such as Black-Scholes options pricing are widely recognized to form a basis of options-like derivatives pricing, assumptions on which they are formed are often not relevant to intricate flows of real markets.
+At Luban we price the preconfirmations with a data-driven approach tailored for the unique supply-demand dynamics of blockspace. While methods such as Black-Scholes options pricing are widely recognized to form a basis of options-like derivatives pricing, assumptions on which they are formed are often not relevant to intricate flows of real markets.
 
 This is particularly pronounced in on-chain blockspace markets. Stabilizing gas prices for end users requires a multi-layered approach that considers both the base fee and tip fee, current block congestion, and eventually, mempool dynamics for intra-block pre-confirmations pricing.
 

--- a/docs/node_operator_setup_guide/installation_and_configuration.mdx
+++ b/docs/node_operator_setup_guide/installation_and_configuration.mdx
@@ -89,11 +89,11 @@ Create `signer-config.toml`, you can see a full example in the [Commit-Boost Cli
 ```toml
 chain = "Holesky"
 
-# the pbs config below are not usefule for commit boost signer, but it is required to make sure config is parsed correctly
+# the pbs config below are not useful for commit boost signer, but it is required to make sure config is parsed correctly
 [pbs]
 port = 18550
 
-# the relays config below are not usefule for commit boost signer, but it is required to make sure config is parsed correctly
+# the relays config below are not useful for commit boost signer, but it is required to make sure config is parsed correctly
 [[relays]]
 id = "mev_relay_0"
 url = "http://b2796db1455143b39c4b6104dddbaf3fdca059009b9df3f61c729bac81cadd355fcc3fc61f5185a4748eb3bf298c0ad0@localhost:18550"


### PR DESCRIPTION
- Corrected "prefonfirmations → preconfirmations" in pricing_preconf.mdx.  
- Fixed typos "usefule → useful" in installation_and_configuration.mdx. 